### PR TITLE
Wrap all Error objects when merging metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-winston",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A configuration driven winston infrastructure",
   "main": "build/index.js",
   "config": {

--- a/src/WrappedLogger.js
+++ b/src/WrappedLogger.js
@@ -42,17 +42,22 @@ export default class WrappedLogger {
   }
 
   applyAdditionalMetadata(meta) {
+    let wrappedMeta = meta;
+    if (meta instanceof Error) {
+      wrappedMeta = { error: meta };
+    }
+
     // Because of the ordering, passed in metadata wins
     if (this.meta) {
       if (typeof this.meta === 'function') {
-        return this.meta(meta);
+        return this.meta(wrappedMeta);
       }
       const base = this.dynamic ? this.dynamic() : {};
-      return Object.assign(base, this.meta, meta);
+      return Object.assign(base, this.meta, wrappedMeta);
     } else if (this.dynamic) {
-      return Object.assign(this.dynamic(), meta);
+      return Object.assign(this.dynamic(), wrappedMeta);
     }
-    return meta;
+    return wrappedMeta;
   }
 
   loggerWithNewSpan() {


### PR DESCRIPTION
Sending bare errors to the logger has data loss if they're not wrapped because of un-enumerable properties so it seems like we should ensure they're always wrapped.